### PR TITLE
Remove semicolon when including

### DIFF
--- a/index.js
+++ b/index.js
@@ -100,7 +100,7 @@ function processInclude(content, filePath, sourceMap) {
       .replace(/(\s+)/gi, " ")
       .replace(/(\/\/|\/\*|\#)(\s+)?=(\s+)?/g, "")
       .replace(/(\*\/)$/gi, "")
-      .replace(/['"]/g, "")
+      .replace(/['";]/g, "")
       .trim();
     var split = includeCommand.split(" ");
     

--- a/test/expected/js/semicolon.js
+++ b/test/expected/js/semicolon.js
@@ -1,0 +1,15 @@
+// whitespace.js
+           // b.js
+    // c.js
+
+  // 2 spaces over
+    // 4 spaces over
+    
+// No spaces over
+        // 8 spaces over
+    // Should be indented below
+      // 2 spaces over
+        // 4 spaces over
+        
+    // No spaces over
+            // 8 spaces over

--- a/test/fixtures/js/semicolon.js
+++ b/test/fixtures/js/semicolon.js
@@ -1,0 +1,7 @@
+// whitespace.js
+           //=     include "deep_path/b.js";
+    //=      include "deep_path/deeper_path/c.js";
+
+//=include "whitespace/a.js";
+    // Should be indented below
+    //=include "whitespace/a.js";

--- a/test/main.js
+++ b/test/main.js
@@ -152,4 +152,23 @@ describe("gulp-include", function () {
       }))
       .pipe(assert.end(done));
   });
+
+  it("should remove semicolon when including", function (done) {
+    var file = new gutil.File({
+      base: "test/fixtures/",
+      path: "test/fixtures/js/semicolon.js",
+      contents: fs.readFileSync("test/fixtures/js/semicolon.js")
+    });
+
+    testInclude = include();
+    testInclude.on("data", function (newFile) {
+      should.exist(newFile);
+      should.exist(newFile.contents);
+
+      String(newFile.contents).should.equal(String(fs.readFileSync("test/expected/js/semicolon.js"), "utf8"))
+      done();
+    });
+    testInclude.write(file);
+  });
+
 })


### PR DESCRIPTION
Hello, 

I try your script to build https://github.com/NUKnightLab/TimelineJS3/blob/master/source/js/TL.Timeline.js  

The TimelineJS3 project uses a trailing semicolon ";"

* Example with TimelineJS // @codekit-prepend "core/TL.js";

I adapt your script to remove it.

Regards

Mathieu